### PR TITLE
Fix Whatsapp redirect function typo

### DIFF
--- a/src/components/WhatsappForm.tsx
+++ b/src/components/WhatsappForm.tsx
@@ -30,7 +30,7 @@ export default function WhatsappForm() {
       .trim();
   };
 
-  const redirectToWatsapp = (phone: string) => {
+  const redirectToWhatsapp = (phone: string) => {
     const url = `https://wa.me/${selectedCountry.number}${phone}`;
     window.location.href = url;
   };
@@ -39,7 +39,7 @@ export default function WhatsappForm() {
     e.preventDefault();
     const phone = parsePhoneNumber(rawPhone);
 
-    redirectToWatsapp(phone);
+    redirectToWhatsapp(phone);
   };
 
   const handleCountryChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -74,7 +74,7 @@ export default function WhatsappForm() {
 
     if (rawPhone) {
       const phone = parsePhoneNumber(rawPhone);
-      redirectToWatsapp(phone);
+      redirectToWhatsapp(phone);
     }
   }, []);
 


### PR DESCRIPTION
## Summary
- rename `redirectToWatsapp` to `redirectToWhatsapp`
- update all function calls

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_687fda41432c832c90f06dc641791bec