### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 8
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 22


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run tests with pnpm

## Testing
- `pnpm test` *(fails: Unsupported engine warning)*

------
https://chatgpt.com/codex/tasks/task_e_687fe8fa21e8832c962f6828a4dad8ed