### PR TITLE
Add basic PWA service worker

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,40 @@
+const CACHE_NAME = 'whatsapp-pwa-cache-v1';
+const OFFLINE_URLS = ['/', '/manifest.json'];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(OFFLINE_URLS)),
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key)),
+      ),
+    ),
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  if (!event.request.url.startsWith(self.location.origin)) return;
+
+  event.respondWith(
+    caches.match(event.request).then((cached) => {
+      if (cached) return cached;
+      return fetch(event.request)
+        .then((response) => {
+          if (response && response.status === 200) {
+            const responseClone = response.clone();
+            caches.open(CACHE_NAME).then((cache) => cache.put(event.request, responseClone));
+          }
+          return response;
+        })
+        .catch(() => caches.match('/'));
+    }),
+  );
+});

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -60,5 +60,12 @@ import WhatsappForm from "../components/WhatsappForm.tsx";
         <WhatsappForm client:load />
       </section>
     </main>
+    <script>
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', () => {
+          navigator.serviceWorker.register('/sw.js');
+        });
+      }
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add a simple `sw.js` with caching logic
- register the service worker from the main page

## Testing
- `pnpm run test`

------
https://chatgpt.com/codex/tasks/task_e_687feab6d108832c89320b1dd0a0257e